### PR TITLE
Patch 1

### DIFF
--- a/signin/utils.py
+++ b/signin/utils.py
@@ -1,3 +1,8 @@
 def get_client_ip(request):
-    ip = request.META.get('REMOTE_ADDR')
+    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+    if x_forwarded_for:
+        # Take the last entry which is not spoofable
+        ip = x_forwarded_for.split(',')[-1]
+    else:
+        ip = request.META.get('REMOTE_ADDR')
     return ip

--- a/signin/utils.py
+++ b/signin/utils.py
@@ -1,7 +1,3 @@
 def get_client_ip(request):
-    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
-    if x_forwarded_for:
-        ip = x_forwarded_for.split(',')[0]
-    else:
-        ip = request.META.get('REMOTE_ADDR')
+    ip = request.META.get('REMOTE_ADDR')
     return ip


### PR DESCRIPTION
the code on : https://github.com/jakhax/slack-sign-in-bot/blob/master/signin/utils.py
would check the ip using X-FORWARDED-FOR header which is spoofable.

Hence anyone could spoof their ip address to moringa school's ip and get authenticated.
More info here: https://httpd.apache.org/docs/current/mod/mod_remoteip.html#remoteiptrustedproxy